### PR TITLE
Not-null MRR change in churn months

### DIFF
--- a/models/mrr/stripe_mrr.sql
+++ b/models/mrr/stripe_mrr.sql
@@ -23,7 +23,7 @@ mrr_with_changes as (
             lag(mrr) over (partition by customer_id order by date_month),
             0) as prior_mrr,
 
-        mrr - coalesce(
+        coalesce(mrr,0) - coalesce(
             lag(mrr) over (partition by customer_id order by date_month),
             0
             ) as mrr_change


### PR DESCRIPTION
Currently, if MRR is null for a month (as in a churn month with no invoices), MRR change for that month will also be null. Instead, we should have the previous month's MRR (`prior_mrr`) as a negative number. I propose `coalesce(mrr,0)`.